### PR TITLE
🔀::[#26] loginVC에서는 navigationBar가 안내려게끔 수정

### DIFF
--- a/Miso/Sources/Presentation/Auth/Login/View/LoginVC.swift
+++ b/Miso/Sources/Presentation/Auth/Login/View/LoginVC.swift
@@ -180,6 +180,11 @@ final class LoginVC: BaseVC<AuthReactor> {
             .disposed(by: disposeBag)
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.navigationBar.prefersLargeTitles = false
+    }
+    
     override func viewDidAppear(_ animated: Bool) {
         textFieldView.snp.updateConstraints {
             $0.top.equalTo(misoIntroStackview.snp.bottom).offset(bound.height / 7.1)


### PR DESCRIPTION
loginVC의 viewWillAppear 메서드에 navigationBar의 largeTitle을 취소하는 코드를 넣어 보이지 않게 구현하였습니다.